### PR TITLE
ActiveStorageでユーザーアイコン作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "jbuilder", "~> 2.5"
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
+gem "mini_magick", "~> 4.8"
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -283,6 +284,7 @@ DEPENDENCIES
   kaminari
   kaminari-i18n
   listen (>= 3.0.5, < 3.2)
+  mini_magick (~> 4.8)
   omniauth
   omniauth-github
   puma (~> 3.11)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 
   protected
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :postal_code, :street_address, :self_introduction])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :postal_code, :street_address, :self_introduction])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :icon, :postal_code, :street_address, :self_introduction])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :icon, :postal_code, :street_address, :self_introduction])
     end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -26,7 +26,19 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # PUT /resource
   def update
-    super
+    @user = User.find(current_user.id)
+
+    if @user.is_github_user
+      if @user.update_without_current_password sign_up_params
+        sign_in @user, bypass: true
+        set_flash_message :notice, :updated
+        redirect_to after_update_path_for(@user)
+      else
+        render "edit"
+      end
+    else
+      super
+    end
   end
 
   # DELETE /resource

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -28,7 +28,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def update
     @user = User.find(current_user.id)
 
-    if @user.is_github_user
+    if @user.provider == "github"
       if @user.update_without_current_password sign_up_params
         sign_in @user, bypass: true
         set_flash_message :notice, :updated

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,16 @@ class User < ApplicationRecord
     user
   end
 
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+    if params[:password].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation) if params[:password_confirmation].blank?
+    end
+    clean_up_passwords
+    update_attributes(params, *options)
+  end
+
   def self.create_unique_string
     SecureRandom.uuid
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   paginates_per 5
+  has_one_attached :icon
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -18,7 +19,8 @@ class User < ApplicationRecord
         provider: auth.provider,
         uid:      auth.uid,
         email:    auth.info.email,
-        password: Devise.friendly_token[0, 20]
+        password: Devise.friendly_token[0, 20],
+        is_github_user: true
       )
     end
     user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,8 +19,7 @@ class User < ApplicationRecord
         provider: auth.provider,
         uid:      auth.uid,
         email:    auth.info.email,
-        password: Devise.friendly_token[0, 20],
-        is_github_user: true
+        password: Devise.friendly_token[0, 20]
       )
     end
     user

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -11,6 +11,10 @@ h2
     br
     = f.email_field :email, autocomplete: "email"
   .field
+    = f.label :icon
+    br
+    = f.file_field :icon
+  .field
     = f.label :postal_code, autocomplete: "postal-code"
     br
     = f.text_field :postal_code

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -26,33 +26,35 @@ h2
     = f.label :self_introduction
     br
     = f.text_field :self_introduction
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    div
-      = (t "devise.registrations.edit.currently_waiting_confirmation_for_email", {email: resource.unconfirmed_email})
-  .field
-    = f.label :password
-    i
-      | (
-      = t "devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it"
-      | )
-    br
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
+  
+  - if @user.provider == ""
+    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+      div
+        = (t "devise.registrations.edit.currently_waiting_confirmation_for_email", {email: resource.unconfirmed_email})
+    .field
+      = f.label :password
+      i
+        | (
+        = t "devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it"
+        | )
       br
-      em
-        = t(:num_characters_minimum, {num: @minimum_password_length})
-  .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    i
-      | (
-      = t "devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes"
-      | )
-    br
-    = f.password_field :current_password, autocomplete: "current-password"
+      = f.password_field :password, autocomplete: "new-password"
+      - if @minimum_password_length
+        br
+        em
+          = t(:num_characters_minimum, {num: @minimum_password_length})
+    .field
+      = f.label :password_confirmation
+      br
+      = f.password_field :password_confirmation, autocomplete: "new-password"
+    .field
+      = f.label :current_password
+      i
+        | (
+        = t "devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes"
+        | )
+      br
+      = f.password_field :current_password, autocomplete: "current-password"
   .actions
     = f.submit (t "devise.registrations.edit.update")
 = button_to (t "devise.registrations.edit.cancel_my_account"), registration_path(resource_name), data: { confirm: (t "devise.registrations.edit.are_you_sure") }, method: :delete

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -11,6 +11,10 @@ h2
     br
     = f.email_field :email, autocomplete: "email"
   .field
+    = f.label :icon
+    br
+    = f.file_field :icon
+  .field
     = f.label :postal_code, autocomplete: "postal-code"
     br
     = f.text_field :postal_code

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -11,6 +11,13 @@ strong
 p
   = @user.email
 strong
+  = User.human_attribute_name("icon")
+p
+  - if @user.icon.attached?
+    = image_tag @user.icon
+  -  else
+    = "no image"
+strong
   = User.human_attribute_name("postal_code")
 p
   = @user.postal_code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         postal_code: Postal code
         street_address: Street address
         self_introduction: Self introduction
+        icon: Icon
       book:
         title: title
         memo: memo

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,6 +38,7 @@ ja:
         postal_code: 郵便番号
         street_address: 住所
         self_introduction: 自己紹介
+        icon: アイコン
       book:
         title: タイトル
         memo: メモ

--- a/db/migrate/20190706073718_devise_create_users.rb
+++ b/db/migrate/20190706073718_devise_create_users.rb
@@ -38,6 +38,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :postal_code
       t.string :street_address
       t.string :self_introduction
+      t.boolean :is_github_user, null: false, default: false
 
       t.timestamps null: false
     end

--- a/db/migrate/20190706073718_devise_create_users.rb
+++ b/db/migrate/20190706073718_devise_create_users.rb
@@ -38,7 +38,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :postal_code
       t.string :street_address
       t.string :self_introduction
-      t.boolean :is_github_user, null: false, default: false
 
       t.timestamps null: false
     end

--- a/db/migrate/20190719095002_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20190719095002_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,6 @@ ActiveRecord::Schema.define(version: 2019_07_19_095002) do
     t.string "postal_code"
     t.string "street_address"
     t.string "self_introduction"
-    t.boolean "is_github_user", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "provider", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_12_070237) do
+ActiveRecord::Schema.define(version: 2019_07_19_095002) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
   create_table "books", force: :cascade do |t|
     t.string "title"
     t.text "memo"
@@ -52,6 +73,7 @@ ActiveRecord::Schema.define(version: 2019_07_12_070237) do
     t.string "postal_code"
     t.string "street_address"
     t.string "self_introduction"
+    t.boolean "is_github_user", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "provider", default: "", null: false


### PR DESCRIPTION
# 追加機能とその詳細
- プロフィールにアイコン追加
- 登録時点で「GitHub認証ユーザー」と「通常ユーザー」を区別
  - プロフィールの情報変更
    - GitHub認証ユーザー
      - パスワード不要
    - 通常ユーザー
      - パスワード必要

## 参考画像

<img width="706" alt="スクリーンショット 2019-07-26 16 55 22" src="https://user-images.githubusercontent.com/42843963/61935798-35a67e80-afc6-11e9-8a39-b9d6e8c5dec2.png">


